### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -43,6 +43,10 @@ jobs:
     name: 'Build & Push Image'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: write
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/vijayjirange/python-demoapp/security/code-scanning/4](https://github.com/vijayjirange/python-demoapp/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `Build & Push Image` job to explicitly define the minimal permissions required. Based on the operations performed in this job:
- `contents: read` is needed to access the repository contents.
- `packages: write` is required to push the Docker image to the container registry.
- `actions: write` is needed to trigger other workflows using the `workflow-dispatch` action.

The `permissions` block will be added at the job level to limit its scope to the `Build & Push Image` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
