### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.codeql/config.yml
+++ b/.codeql/config.yml
@@ -1,4 +1,4 @@
 name: "CodeQL Custom Config"
 queries:
-  - uses: github/codeql/javascript-queries
-  - uses: github/codeql/python-queries
+  - uses: codeql/javascript-queries
+  - uses: codeql/python-queries

--- a/.codeql/config.yml
+++ b/.codeql/config.yml
@@ -1,4 +1,4 @@
 name: "CodeQL Custom Config"
 queries:
-  - uses: github/codeql/javascript-queries@latest
+  - uses: github/codeql/javascript-all
   - uses: github/codeql/python-queries@latest

--- a/.codeql/config.yml
+++ b/.codeql/config.yml
@@ -1,4 +1,4 @@
 name: "CodeQL Custom Config"
 queries:
-  - uses: codeql/javascript-queries
-  - uses: codeql/python-queries
+  - uses: github/codeql/javascript-queries
+  - uses: github/codeql/python-queries

--- a/.codeql/config.yml
+++ b/.codeql/config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL Custom Config"
+queries:
+  - uses: codeql/javascript-queries
+  - uses: codeql/python-queries

--- a/.codeql/config.yml
+++ b/.codeql/config.yml
@@ -1,4 +1,4 @@
 name: "CodeQL Custom Config"
 queries:
-  - uses: github/codeql/javascript-queries
-  - uses: github/codeql/python-queries
+  - uses: github/codeql/javascript-queries@latest
+  - uses: github/codeql/python-queries@latest

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -15,6 +15,8 @@ jobs:
   test:
     name: 'Tests & Linting'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 'Run linting'
         run: make lint
@@ -50,7 +50,7 @@ jobs:
       actions: write
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Nicer than using github runid, I think, will be picked up automatically by make
       - name: 'Create datestamp image tag'

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -28,8 +28,7 @@ jobs:
         run: make test-report
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v2
-        # Disabled when running locally with the nektos/act tool
+        uses: actions/upload-artifact@v3
         if: ${{ always() && !env.ACT }}
         with:
           name: test-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,11 +67,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        config-file: ".codeql/config.yml"
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
+  uses: github/codeql-action/init@v3
+  with:
+    config-file: ".codeql/config.yml"
+    languages: ${{ matrix.language }}
+    build-mode: ${{ matrix.build-mode }}
+    queries: +security-extended,security-and-quality
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,7 +72,9 @@ jobs:
     config-file: ".codeql/config.yml"
     languages: ${{ matrix.language }}
     build-mode: ${{ matrix.build-mode }}
-    queries: +security-extended,security-and-quality
+    queries:
+      - uses: security-extended
+      - uses: security-and-quality
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,6 +69,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
+        config-file: ".codeql/config.yml"
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,9 @@ jobs:
   publish-image:
     name: "Build & Publish"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.2
 py-cpuinfo==7.0.0
 psutil==5.8.0
-gunicorn==20.1.0
+gunicorn==23.0.0
 black==20.8b1
 flake8==3.9.0
 pytest==6.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/vijayjirange/python-demoapp/security/code-scanning/7](https://github.com/vijayjirange/python-demoapp/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository and pushing Docker images to a container registry, the minimal required permissions are `contents: read` (to read the repository contents) and `packages: write` (to push the Docker images). These permissions will be added at the job level to limit their scope to the `publish-image` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
